### PR TITLE
change resize grid behavior

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -14,11 +14,6 @@ function init(gridSize) {
 function createGrid(gridSize) {
     let gridArea = document.getElementById("grid-area");
 
-    // Restricting size of grid so it doesn't freeze the brwoser
-    gridSize = (gridSize > 100) ? 100 
-             : (gridSize < 0) ? 16
-             : gridSize;
-
     gridArea.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
 
     for (let i = 0; i < gridSize ** 2; i++) {
@@ -47,14 +42,28 @@ function reset() {
     });
 }
 
-function resizeGrid() {
-    cells = getCells();
+function isNumeric(value) {
+    return /^\d+$/.test(value);
+}
+   
+function promptForNumber() {
+    let processed_input
+    do {
+	let raw_input = prompt("Enter a number between 2 and 25:");
+	    if (raw_input === null) { return null }
+	processed_input = Number(raw_input)
+    } while (!isNumeric(processed_input) || processed_input < 2 || processed_input > 25)
+    return processed_input
+}	  
 
+function resizeGrid() {
+    new_size = promptForNumber()
+    if (new_size === null) { return }
+    cells = getCells();
     cells.forEach((cell) => {
         cell.parentNode.removeChild(cell);
     });
-
-    init(prompt("How big should the grid be?", 16));
+    init(new_size)
 }
 
 function getCells() {


### PR DESCRIPTION
* fixes #10
    * when the Cancel button in the resize grid prompt is clicked, the grid retains the state it was in before the resize grid button was pressed
* changes the resize grid prompt to give the user more specific instructions
* restricts acceptable grid size to 2-25 (inclusive)
    * the resize grid prompt will re-appear until the user provides a valid number or presses the cancel button

[Screencast From 2025-06-02 23-20-51.webm](https://github.com/user-attachments/assets/af5e788e-dbd2-4b11-acdc-6a0ec7c79ed4)
